### PR TITLE
fix: bump sc_firebat, sc_medic, sc_tank version to 2.0.0

### DIFF
--- a/sc_firebat/openpeon.json
+++ b/sc_firebat/openpeon.json
@@ -2,7 +2,7 @@
   "cesp_version": "1.0",
   "name": "sc_firebat",
   "display_name": "StarCraft Firebat",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "kschmidtjr1",
     "github": "kschmidtjr1"

--- a/sc_medic/openpeon.json
+++ b/sc_medic/openpeon.json
@@ -2,7 +2,7 @@
   "cesp_version": "1.0",
   "name": "sc_medic",
   "display_name": "StarCraft Medic",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "kschmidtjr1",
     "github": "kschmidtjr1"

--- a/sc_tank/openpeon.json
+++ b/sc_tank/openpeon.json
@@ -2,7 +2,7 @@
   "cesp_version": "1.0",
   "name": "sc_tank",
   "display_name": "StarCraft Siege Tank",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "kschmidtjr1",
     "github": "kschmidtjr1"


### PR DESCRIPTION
## Summary

Fixes the version regression introduced in #9. The version went from `1.1.0` → `1.0.0` (a downgrade), which would confuse update checks.

Bumps all three reworked packs to `v2.0.0` since the audio file set was completely replaced (breaking change). This matches the precedent set by `sc_scv` in PR #3 (workdd v1.0.0 → harrymunro v2.0.0).

### Changes

- `sc_firebat/openpeon.json`: `1.0.0` → `2.0.0`
- `sc_medic/openpeon.json`: `1.0.0` → `2.0.0`
- `sc_tank/openpeon.json`: `1.0.0` → `2.0.0`
